### PR TITLE
Fix index value typos in communication documentation

### DIFF
--- a/docs/communication.md
+++ b/docs/communication.md
@@ -52,8 +52,8 @@ i2cMessage[1] = pixel[0][0] | (pixel[0][1] << 4);
 i2cMessage[2] = pixel[0][2] | (pixel[0][3] << 4);
 i2cMessage[3] = pixel[0][4] | (pixel[0][5] << 4);
 i2cMessage[4] = pixel[0][6] | (pixel[0][7] << 4);
-i2cMessage[6] = pixel[1][0] | (pixel[1][0] << 4);
-i2cMessage[7] = pixel[1][2] | (pixel[1][3] << 4);
+i2cMessage[5] = pixel[1][0] | (pixel[1][0] << 4);
+i2cMessage[6] = pixel[1][2] | (pixel[1][3] << 4);
 ... 
 i2cMessage[32] = pixel[7][6] | (pixel[7][7] << 4);
 ```


### PR DESCRIPTION
There are some small typos in the documentation. Only the first byte of the entire 33 byte message is special and after that the i2cMessage index values should proceed in order from 1 to 32. In the current documentation, the values go from 1-4, then skip 5, then proceed to 6-32. The 5 index should not be skipped.